### PR TITLE
Publish opensearch file for custom search in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <meta name="keywords" content="duckduckgo, duck duck go, ddg, lmddgtfy, let me duckduckgo that for you, lmdtfy, let me duck that for you, let me search that for you">
     <meta name="wot-verification" content="2be96ee9f850fd264aec">
     <link rel="canonical" href="https://lmddgtfy.net/">
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="Let Me DuckDuckGo That For You" />
 
     <title>Let Me DuckDuckGo That For You - LMDDGTFY</title>
 


### PR DESCRIPTION
The opensearch XML file is a great idea; publishing it in the `index.html` will allow Firefox users to add LMDDGTFY as a custom search engine.